### PR TITLE
Corrected errors introduced with previous commit

### DIFF
--- a/languages/fr.yaml
+++ b/languages/fr.yaml
@@ -12,7 +12,7 @@ fr:
   list: Afficher
   none: Aucun
   view: Voir
-  in:  dans
+  in: dans
 
   # Nav
   dashboard: Tableau de bord
@@ -22,12 +22,12 @@ fr:
   system: Système
   help: Aide
   view_site: Voir le site
-  logout: Se déconnecter
-  logs:  Journaux
+  logout: Déconnexion
+  logs: Journaux
 
   # Entries
   entry: Article
-  entries:  Articles
+  entries: Articles
   create_entry: Ajouter un nouvel article
   delete_entry: Supprimer l'article
   view_entry: Voir l'article
@@ -39,17 +39,17 @@ fr:
   site_pages: Pages du site
   new_child_page: Nouvelle page enfant
   view_page: Voir la page
-  delete_page:  Supprimer la page
+  delete_page: Supprimer la page
   select_new_page_type: Choisir le type de la nouvelle page
-  parent:  Parent
+  parent: Parent
 
-  update_available:  Mise à jour disponible
-  up_to_date:  à jour
-  offline:  Le panneau de contrôle est actuellement hors ligne.
+  update_available: Mise à jour disponible
+  up_to_date: Vous êtes à jour !
+  offline: Le panneau de contrôle est actuellement hors ligne.
 
   # Publish
   title: Titre
-  slug: Ligne bloc
+  slug: Label court
   date: Date
   number: Numéro
   editing: Édition
@@ -67,7 +67,7 @@ fr:
   hidden: Caché
 
   # Members and forms
-  login: Se connecter
+  login: Connexion
   admin: Admin
   username: Nom d'utilisateur
   password: Mot de passe


### PR DESCRIPTION
Corrected previous commit which introduced double spaces in front of
new translations. Sorry 'bout that.

Also change 3 translations.
