### PR TITLE
Updated entries 'confirm_action'  key for DE, EN, FR, PL, JA and template

### DIFF
--- a/languages/de-informal.yaml
+++ b/languages/de-informal.yaml
@@ -39,7 +39,7 @@ translations:
   list_entries: Einträge auflisten
   take_action: Aktion
   delete_entries: Einträge löschen
-  confirm_delete: Ja, lösche diese Einträge.
+  confirm_action: Ja, lösche diese Einträge.
 
   # Pages
   page: Seite

--- a/languages/de.yaml
+++ b/languages/de.yaml
@@ -40,7 +40,7 @@ translations:
   list_entries: Einträge auflisten
   take_action: Aktion
   delete_entries: Einträge löschen
-  confirm_delete: Ja, lösche diese Einträge.
+  confirm_action: Ja, lösche diese Einträge.
 
   # Pages
   page: Seite

--- a/languages/en.yaml
+++ b/languages/en.yaml
@@ -40,7 +40,7 @@ translations:
   list_entries: List Entries
   take_action: Take Action
   delete_entries: Delete Entries
-  confirm_delete: Yes I'm Sure
+  confirm_action: Yes I'm Sure
 
   # Pages
   page: Page

--- a/languages/fr.yaml
+++ b/languages/fr.yaml
@@ -40,7 +40,7 @@ translations:
   list_entries: Afficher les articles
   take_action: Action
   delete_entries: Supprimer les articles
-  confirm_delete: Oui, je confirme
+  confirm_action: Oui, je confirme
 
   # Pages
   page: Page

--- a/languages/ja.yaml
+++ b/languages/ja.yaml
@@ -40,7 +40,7 @@ translations:
   list_entries: エントリーを一覧 # Not used?
   take_action: アクションを選択
   delete_entries: エントリーを削除
-  confirm_delete: はい、削除します
+  confirm_action: はい、削除します
 
   # Pages
   page: ページ

--- a/languages/pl.yaml
+++ b/languages/pl.yaml
@@ -40,7 +40,7 @@ translations:
   list_entries: Pokaż wpisy
   take_action: Akcja
   delete_entries: Usuń wpisy
-  confirm_delete: "Tak, jestem pewien."
+  confirm_action: "Tak, jestem pewien."
 
   # Pages
   page: Strona

--- a/languages/template.yaml
+++ b/languages/template.yaml
@@ -39,7 +39,7 @@ translations:
   list_entries: 
   take_action: 
   delete_entries: 
-  confirm_delete: 
+  confirm_action: 
 
   # Pages
   page: 


### PR DESCRIPTION
Renamed the `confirm_delete` key to `confirm_action` for German, English, French, Polish and Japanese. (Statamic calls `confirm_action`).
Updated template also.
